### PR TITLE
Update signature of `repeat()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,12 +303,12 @@ const Modal = (isHidden, children) => div(
 )
 ```
 
-What about rendering dynamic lists of children? For this, we can use `repeat(view, signal, extra)`. It takes a signal of `Map<Key, Item>`, and will efficiently re-render children, updating, moving, or removing elements as needed, making the minimal number of DOM modifications.
+What about rendering dynamic lists of children? For this, we can use `repeat(signal, view)`. It takes a signal of `Map<Key, Item>`, and will efficiently re-render children, updating, moving, or removing elements as needed, making the minimal number of DOM modifications.
 
 ```js
 const Todos = todos => div(
   {className: 'todos'},
-  repeat(Todo, todos)
+  repeat(todos, Todo)
 )
 ```
 

--- a/dist/hyperscript.d.ts
+++ b/dist/hyperscript.d.ts
@@ -1,3 +1,4 @@
+import { Signal } from './spellcaster.js';
 /**
  * Get an auto-incrementing client-side ID value.
  * IDs are NOT guaranteed to be stable across page refreshes.
@@ -13,12 +14,12 @@ export declare const getId: <Key, Item extends Identifiable>(item: Item) => any;
 /** Index a collection by ID */
 export declare const indexById: <Key, Item extends Identifiable>(iter: Iterable<Item>) => Map<Key, Item>;
 /** A view-constructing function */
-export type View<State, Msg> = (state: () => State, send: (msg: Msg) => void) => HTMLElement;
+export type View<State> = (state: Signal<State>) => HTMLElement;
 /**
  * Create a function to efficiently render a dynamic list of views on a
  * parent element.
  */
-export declare const repeat: <Key, State, Msg>(view: View<State, Msg>, states: () => Map<Key, State>, send: (msg: Msg) => void) => (parent: HTMLElement) => void;
+export declare const repeat: <Key, State>(states: Signal<Map<Key, State>>, view: View<State>) => (parent: HTMLElement) => void;
 /**
  * Insert element at index.
  * If element is already at index, this function is a no-op
@@ -33,7 +34,7 @@ export declare const shadow: (...children: Array<HTMLElement | string>) => (pare
  * Write a value or signal of values to the text content of a parent element.
  * Value will be coerced to string. If nullish, will be coerced to empty string.
  */
-export declare const text: (text: (() => any) | any) => (parent: any) => void;
+export declare const text: (text: Signal<any> | any) => (parent: any) => void;
 /**
  * Signals-aware hyperscript.
  * Create an element that can be updated with signals.
@@ -44,8 +45,8 @@ export declare const text: (text: (() => any) | any) => (parent: any) => void;
  *  or an array of HTMLElements and strings to append. Optional.
  * @returns {HTMLElement}
  */
-export declare const h: (tag: string, properties: Record<string, any> | (() => Record<string, any>), configure?: (string | HTMLElement)[] | ((element: HTMLElement) => void)) => HTMLElement;
-type TagFactory = (properties: Record<string, any> | (() => Record<string, any>), configure?: (Array<HTMLElement | string> | ((element: HTMLElement) => void))) => HTMLElement;
+export declare const h: (tag: string, properties: Record<string, any> | Signal<Record<string, any>>, configure?: (string | HTMLElement)[] | ((element: HTMLElement) => void)) => HTMLElement;
+type TagFactory = (properties: Record<string, any> | Signal<Record<string, any>>, configure?: (Array<HTMLElement | string> | ((element: HTMLElement) => void))) => HTMLElement;
 /**
  * Create a tag factory function - a specialized version of `h()` for a
  * specific tag.

--- a/dist/hyperscript.js
+++ b/dist/hyperscript.js
@@ -23,7 +23,7 @@ const __key__ = Symbol('list item key');
  * Create a function to efficiently render a dynamic list of views on a
  * parent element.
  */
-export const repeat = (view, states, send) => (parent) => effect(() => {
+export const repeat = (states, view) => (parent) => effect(() => {
     // Build an index of children and a list of children to remove.
     // Note that we must build a list of children to remove, since
     // removing in-place would change the live node list and bork iteration.
@@ -46,7 +46,7 @@ export const repeat = (view, states, send) => (parent) => effect(() => {
             insertElementAt(parent, child, index);
         }
         else {
-            const child = view(takeValues(() => states().get(key)), send);
+            const child = view(takeValues(() => states().get(key)));
             child[__key__] = key;
             insertElementAt(parent, child, index);
         }


### PR DESCRIPTION
Remove send function from signature, and switch argument order.
The new function signature mirrors the signature of Lit's repeat.

Intended use:

```js
repeat(states, MyView)

repeat(states, state => MyView2(state, send))

repeat(states, state => {
  const taggedSend = tag(send, state().id)
  return MyView3(state, taggedSend))
})
```

It's better to allow the parent view to use closure to pass down a
send function if needed. This gives more flexibility to pass down a
mapped or unmapped send function, or no send function at all.