### PR TITLE
Support cleanup and dispose for effect

### DIFF
--- a/dist/hyperscript.d.ts
+++ b/dist/hyperscript.d.ts
@@ -19,7 +19,7 @@ export type View<State> = (state: Signal<State>) => HTMLElement;
  * Create a function to efficiently render a dynamic list of views on a
  * parent element.
  */
-export declare const repeat: <Key, State>(states: Signal<Map<Key, State>>, view: View<State>) => (parent: HTMLElement) => void;
+export declare const repeat: <Key, State>(states: Signal<Map<Key, State>>, view: View<State>) => (parent: HTMLElement) => () => void;
 /**
  * Insert element at index.
  * If element is already at index, this function is a no-op
@@ -34,7 +34,7 @@ export declare const shadow: (...children: Array<HTMLElement | string>) => (pare
  * Write a value or signal of values to the text content of a parent element.
  * Value will be coerced to string. If nullish, will be coerced to empty string.
  */
-export declare const text: (text: Signal<any> | any) => (parent: any) => void;
+export declare const text: (text: Signal<any> | any) => (parent: any) => () => void;
 /**
  * Signals-aware hyperscript.
  * Create an element that can be updated with signals.

--- a/dist/spellcaster.d.ts
+++ b/dist/spellcaster.d.ts
@@ -59,8 +59,21 @@ export declare const computed: <T>(compute: Signal<T>) => () => T;
  * `perform` is executed within a reactive scope, so signals referenced within
  * `perform` will automatically cause `perform` to be re-run when signal
  * state changes.
+ *
+ * `perform` may optionally return a zero-argument cleanup function that will
+ * be called just before the effect is re-run.
+ *
+ * Returns a dispose function that will end the effect, run cleanup, and
+ * prevent further reactive updates. Note it is not typically necessary to
+ * dispose an effect, so in most cases you can ignore the returned dispose
+ * function. Since effects only react to the signals they reference, and
+ * clean up after themselves, you can simply stop referencing a signal to
+ * stop reacting (e.g. using a boolean signal and if statement to turn
+ * on/off an effect). However, the returned dispose function can be useful
+ * when an effect's lifecycle is tied to the lifecycle of a component or class,
+ * and that component or class has a destructor.
  */
-export declare const effect: (perform: () => void) => void;
+export declare const effect: (perform: () => unknown) => () => void;
 /**
  * Transform a signal, returning a computed signal that takes values until
  * the given signal returns null. Once the given signal returns null, the

--- a/dist/spellcaster.js
+++ b/dist/spellcaster.js
@@ -145,12 +145,39 @@ export const computed = (compute) => {
  * `perform` is executed within a reactive scope, so signals referenced within
  * `perform` will automatically cause `perform` to be re-run when signal
  * state changes.
+ *
+ * `perform` may optionally return a zero-argument cleanup function that will
+ * be called just before the effect is re-run.
+ *
+ * Returns a dispose function that will end the effect, run cleanup, and
+ * prevent further reactive updates. Note it is not typically necessary to
+ * dispose an effect, so in most cases you can ignore the returned dispose
+ * function. Since effects only react to the signals they reference, and
+ * clean up after themselves, you can simply stop referencing a signal to
+ * stop reacting (e.g. using a boolean signal and if statement to turn
+ * on/off an effect). However, the returned dispose function can be useful
+ * when an effect's lifecycle is tied to the lifecycle of a component or class,
+ * and that component or class has a destructor.
  */
 export const effect = (perform) => {
+    let isRunning = true;
+    const dispose = () => {
+        if (typeof cleanup === 'function') {
+            cleanup();
+        }
+        isRunning = false;
+    };
     const performEffect = throttled(() => {
-        withTracking(performEffect, perform);
+        if (!isRunning) {
+            return;
+        }
+        if (typeof cleanup === 'function') {
+            cleanup();
+        }
+        cleanup = withTracking(performEffect, perform);
     });
-    withTracking(performEffect, perform);
+    let cleanup = withTracking(performEffect, perform);
+    return dispose;
 };
 /**
  * Transform a signal, returning a computed signal that takes values until

--- a/src/spellcaster.ts
+++ b/src/spellcaster.ts
@@ -180,17 +180,50 @@ export const computed = <T>(compute: Signal<T>) => {
   return read
 }
 
+type Cleanup = () => void
+
 /**
  * Perform a side-effect whenever signals referenced within `perform` change.
  * `perform` is executed within a reactive scope, so signals referenced within
  * `perform` will automatically cause `perform` to be re-run when signal
  * state changes.
+ * 
+ * `perform` may optionally return a zero-argument cleanup function that will
+ * be called just before the effect is re-run.
+ * 
+ * Returns a dispose function that will end the effect, run cleanup, and
+ * prevent further reactive updates. Note it is not typically necessary to
+ * dispose an effect, so in most cases you can ignore the returned dispose
+ * function. Since effects only react to the signals they reference, and
+ * clean up after themselves, you can simply stop referencing a signal to
+ * stop reacting (e.g. using a boolean signal and if statement to turn
+ * on/off an effect). However, the returned dispose function can be useful
+ * when an effect's lifecycle is tied to the lifecycle of a component or class,
+ * and that component or class has a destructor.
  */
-export const effect = (perform: () => void) => {
+export const effect = (perform: () => unknown) => {
+  let isRunning = true
+
+  const dispose = () => {
+    if (typeof cleanup === 'function') {
+      cleanup()
+    }
+    isRunning = false
+  }
+
   const performEffect = throttled(() => {
-    withTracking(performEffect, perform)
+    if (!isRunning) {
+      return
+    }
+    if (typeof cleanup === 'function') {
+      cleanup()
+    }
+    cleanup = withTracking(performEffect, perform)
   })
-  withTracking(performEffect, perform)
+
+  let cleanup = withTracking(performEffect, perform)
+
+  return dispose
 }
 
 /**


### PR DESCRIPTION
This PR modifies effect in two non-breaking ways:

- The closure passed to effect may return a cleanup function. This cleanup function will be run before each update. This is similar to the way `useEffect()` allows for cleanup between renders.
- Effect returns a dispose function which may be called to "turn off" the effect forever. 

 Note it is not typically necessary to dispose an effect, so in most cases you can ignore the returned dispose function. Since effects only react to the signals they reference, and clean up after themselves, you can simply stop referencing a signal to stop reacting (e.g. using a boolean signal and if statement to turn on/off an effect). However, the returned dispose function can be useful when an effect's lifecycle is tied to the lifecycle of a component or class, and that component or class has a destructor.