### PR TITLE
Use npmignore instead of files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
       "types": "./dist/hyperscript.d.ts"
     }
   },
-  "files": [
-    "dist/**/*"
-  ],
   "scripts": {
     "prepare": "tsc -p tsconfig.json",
     "test": "tsc -p tsconfig.json && mocha"


### PR DESCRIPTION
Files makes the include EXCLUSIVE, so only the files mentioned are kept. .npmignore overshadows .gitignore, allowing all files to be added to package unless explicitly removed via .npmignore.