### PR TITLE
Split polyfill into separate bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ TypeScript types are exported using the newer package.json `exports` field. To a
 
 ### As a vanilla JS library
 
-Spellcaster is also available as a vanilla JS modules... no npm or build step necessary!
+Spellcaster is also available as a vanilla JS module... no npm or build step necessary!
 
-To use the Spellcaser as a vanilla JS module, download the zip from the latest release, and then import the library and signals polyfill (provided with the download).
+To use the Spellcaser as a vanilla JS module, download the bundle zip from the latest release, and then import the library and signals polyfill (provided with the download).
 
 In your HTML file, add the following to the head:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ console.log(count()) // 1
 
 So far, so good. But signals have a hidden superpower: they're reactive! When we reference a signal within a rective scope, that scope will re-run whenever the signal value updates.
 
-Spellcaster uses this superpower to offer React-like with vanilla elements. Signals are bound to specific points in the DOM tree, and whenever the signal updates, a fine-grained update is made to the DOM. For example, here's a simple counter app:
+Spellcaster uses this superpower to offer React-like components for vanilla DOM elements. Signals are bound to specific points in the DOM tree, and whenever the signal updates, a fine-grained update is made to the DOM. For example, here's a simple counter app:
 
 ```js
 import {signal} from 'spellcaster/spellcaster.js'

--- a/README.md
+++ b/README.md
@@ -27,45 +27,45 @@ setCount(1)
 console.log(count()) // 1
 ```
 
-So far, so good. But signals have a hidden superpower: they're reactive!
+So far, so good. But signals have a hidden superpower: they're reactive! When we reference a signal within a rective scope, that scope will re-run whenever the signal value updates.
 
-When we reference a signal within a rective scope, that scope will re-run whenever the signal value updates. For example, let's create a derived signal from another signal, using `computed()`.
-
-```js
-import {signal, computed} from 'spellcaster/spellcaster.js'
-
-const [todos, setTodos] = signal([
-  { text: 'Chop wood', isComplete: true },
-  { text: 'Carry water', isComplete: false }
-])
-
-// Create a computed signal from other signals
-const completed = computed(() => {
-  // Re-runs automatically when todos signal changes
-  return todos().filter(todo => todo.isComplete).length
-})
-
-console.log(completed()) // 1
-```
-
-`computed` runs the function you provide within a reactive scope, so when the signal changes, the function is re-run.
-
-What about when you want to react to value changes? That's where `effect` comes in. It lets you perform a side-effect whenever a signal changes:
+Spellcaster uses this superpower to offer React-like with vanilla elements. Signals are bound to specific points in the DOM tree, and whenever the signal updates, a fine-grained update is made to the DOM. For example, here's a simple counter app:
 
 ```js
-// Log every time title changes
-effect(() => console.log(title()))
-```
+import {signal} from 'spellcaster/spellcaster.js'
+import {tags, text} from 'spellcaster/hyperscript.js'
+const {div, button} = tags
 
-Effect is where signals meet the real world. You can use `effect` like you might use `useEffect` in React... to kick off HTTP requests, perform DOM mutations, or anything else that should react to state updates.
+const Counter = () => {
+  const [count, setCount] = signal(0)
+
+  return div(
+    {className: 'counter'},
+    [
+      div({className: 'counter-text'}, text(count)),
+      button(
+        {
+          className: 'counter-button',
+          onclick: () => setCount(count() + 1)
+        },
+        text('Increment')
+      )
+    ]
+  )
+}
+
+document.body.append(Counter())
+```
 
 ## Installation
+
+### Via NPM
 
 ```
 npm install spellcaster
 ```
 
-Then import into JavaScript or TypeScript files:
+Then import into JavaScript or TypeScript:
 
 ```js
 import * as spellcaster from 'spellcaster/spellcaster.js'
@@ -81,6 +81,33 @@ TypeScript types are exported using the newer package.json `exports` field. To a
   "moduleResolution": "node16" // or "nodenext"
 }
 ```
+
+### As a vanilla JS library
+
+Spellcaster is also available as a vanilla JS modules... no npm or build step necessary!
+
+To use the Spellcaser as a vanilla JS module, download the zip from the latest release, and then import the library and signals polyfill (provided with the download).
+
+In your HTML file, add the following to the head:
+
+```html
+<script type="importmap">
+  {
+    "imports": {
+      "signal-polyfill": "./path/to/signal-polyfill.js",
+      "spellcaser": "./path/to/spellcaster.js"
+    }
+  }
+</script>
+```
+
+Now you can import Spellcaster from your vanilla JS module:
+
+```js
+import {signal} from 'spellcaster'
+```
+
+Happy hacking!
 
 ## Creating reactive components with signals
 
@@ -203,6 +230,28 @@ const fizzBuzz = computed(() => {
 You never have to worry about registering and removing listeners, or cancelling subscriptions. Spellcaster manages all of that for you. We call this fine-grained reactivity.
 
 Simple apps that use local component state may not need `computed`, but it comes in handy for complex apps that want to centralize state in one place.
+
+## Performing side-effects with `effect`
+
+What about when you want do something in response to signal changes? This is where `effect` comes in. It lets you perform a side-effect whenever a signal changes:
+
+```js
+// Log every time title changes
+effect(() => console.log(title()))
+```
+
+Effect is where signals meet the real world. You can use `effect` like you might use `useEffect` in React... to kick off HTTP requests, perform DOM mutations, or anything else that should react to state updates.
+
+Effect can also optionally return a function to perform cleanup between updates:
+
+```js
+// Log every time title changes
+effect(() => {
+  const x = new ResourceOfSomeKind()
+  x.perform()
+  return () => x.close()
+})
+```
 
 ## Using `store` to manage state with reducers
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ In your HTML file, add the following to the head:
   {
     "imports": {
       "signal-polyfill": "./path/to/signal-polyfill.js",
-      "spellcaser": "./path/to/spellcaster.js"
+      "spellcaster": "./path/to/spellcaster.js"
     }
   }
 </script>

--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -4,8 +4,16 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title></title>
+  <script type="importmap">
+    {
+      "imports": {
+        "signal-polyfill": "../../bundle/signal-polyfill.js"
+      }
+    }
+  </script>
   <script type="module" src="main.js"></script>
 </head>
 <body>
+  <p>Note: run <code>npm run bundle</code> before trying this example</p>
 </body>
 </html>

--- a/examples/counter/main.js
+++ b/examples/counter/main.js
@@ -1,6 +1,6 @@
-import {signal} from '../../dist/spellcaster.js'
-import {tags, text} from '../../dist/hyperscript.js'
-const {div, button} = tags
+import {signal, hyperscript} from '../../bundle/spellcaster.js'
+const {text} = hyperscript
+const {div, button} = hyperscript.tags
 
 const Counter = () => {
   const [count, setCount] = signal(0)
@@ -20,4 +20,4 @@ const Counter = () => {
   )
 }
 
-document.body.append(Counter())
+document.body.replaceChildren(Counter())

--- a/examples/diamond-problem/index.html
+++ b/examples/diamond-problem/index.html
@@ -4,8 +4,17 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title></title>
+  <script type="importmap">
+    {
+      "imports": {
+        "signal-polyfill": "../../bundle/signal-polyfill.js"
+      }
+    }
+  </script>
   <script type="module" src="main.js"></script>
 </head>
 <body>
+  <p>Note: run <code>npm run bundle</code> before trying this example</p>
+  <p>Open console to see result</p>
 </body>
 </html>

--- a/examples/diamond-problem/main.js
+++ b/examples/diamond-problem/main.js
@@ -2,7 +2,7 @@ import {
   signal,
   computed,
   effect
-} from '../../dist/spellcaster.js'
+} from '../../bundle/spellcaster.js'
 
 const [clock, sendClock] = signal(Date.now())
 

--- a/examples/stress-test/index.html
+++ b/examples/stress-test/index.html
@@ -4,8 +4,17 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title></title>
+  <script type="importmap">
+    {
+      "imports": {
+        "signal-polyfill": "../../bundle/signal-polyfill.js"
+      }
+    }
+  </script>
   <script type="module" src="main.js"></script>
 </head>
 <body>
+  <p>Note: run <code>npm run bundle</code> before trying this example</p>
+  <p>Open console to see result</p>
 </body>
 </html>

--- a/examples/stress-test/main.js
+++ b/examples/stress-test/main.js
@@ -2,7 +2,7 @@ import {
   signal,
   computed,
   effect
-} from '../../dist/spellcaster.js'
+} from '../../bundle/spellcaster.js'
 
 const [a, setA] = signal(0)
 const [b, setB] = signal(0)

--- a/examples/todos/index.html
+++ b/examples/todos/index.html
@@ -5,8 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title></title>
   <link rel="stylesheet" href="main.css">
+  <script type="importmap">
+    {
+      "imports": {
+        "signal-polyfill": "../../bundle/signal-polyfill.js"
+      }
+    }
+  </script>
   <script type="module" src="main.js"></script>
 </head>
 <body>
+  <p>Note: run <code>npm run bundle</code> before trying this example</p>
 </body>
 </html>

--- a/examples/todos/main.js
+++ b/examples/todos/main.js
@@ -2,7 +2,7 @@ import {
   store,
   computed,
   logware
-} from '../../dist/spellcaster.js'
+} from '../../bundle/spellcaster.js'
 
 import {
   tags,
@@ -141,4 +141,4 @@ const [state, send] = store({
 window.state = state
 
 const appEl = App(state, send)
-document.body.append(appEl)
+document.body.replaceChildren(appEl)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "prepare": "tsc -p tsconfig.json",
-    "bundle_lib": "esbuild --bundle --minify --sourcemap --external:signal-polyfill --target=esnext --platform=browser --format=esm --outfile=bundle/index.js src/index.ts",
+    "bundle_lib": "esbuild --bundle --minify --sourcemap --external:signal-polyfill --target=esnext --platform=browser --format=esm --outfile=bundle/spellcaster.js src/index.ts",
     "bundle_polyfill": "esbuild --bundle --minify --sourcemap --target=esnext --platform=browser --format=esm --outfile=bundle/signal-polyfill.js src/signal-polyfill.ts",
     "bundle": "npm run bundle_polyfill && npm run bundle_lib",
     "test": "tsc -p tsconfig.json && mocha"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   },
   "scripts": {
     "prepare": "tsc -p tsconfig.json",
-    "bundle": "esbuild --bundle --minify --sourcemap --target=esnext --platform=browser --format=esm --outfile=bundle/index.js src/index.ts",
+    "bundle_lib": "esbuild --bundle --minify --sourcemap --external:signal-polyfill --target=esnext --platform=browser --format=esm --outfile=bundle/index.js src/index.ts",
+    "bundle_polyfill": "esbuild --bundle --minify --sourcemap --target=esnext --platform=browser --format=esm --outfile=bundle/signal-polyfill.js src/signal-polyfill.ts",
+    "bundle": "npm run bundle_polyfill && npm run bundle_lib",
     "test": "tsc -p tsconfig.json && mocha"
   },
   "directories": {

--- a/src/signal-polyfill.ts
+++ b/src/signal-polyfill.ts
@@ -1,0 +1,1 @@
+export {Signal} from 'signal-polyfill'

--- a/src/spellcaster.ts
+++ b/src/spellcaster.ts
@@ -1,4 +1,4 @@
-import {Signal} from 'signal-polyfill'
+import {Signal} from './signal-polyfill.js'
 
 /**
  * A signal is a zero-argument function that returns a value.


### PR DESCRIPTION
This allows users of vanilla JS module to code-share signal polyfill.

See https://x.com/justinfagnani/status/1808975924995764324

Vanilla bundle users should add the following import map to their HTML head:

```html
<script type="importmap">
  {
    "imports": {
      "signal-polyfill": "./path/to/signal-polyfill.js",
      "spellcaster": "./path/to/spellcaster.js"
    }
  }
</script>
```