### PR TITLE
Allow middleware to be undefined

### DIFF
--- a/src/spellcaster.ts
+++ b/src/spellcaster.ts
@@ -187,12 +187,12 @@ export const store = <State, Msg>(
     state: initial,
     update,
     msg = undefined,
-    middleware: middleware = id,
+    middleware = id,
   }: {
     state: State,
     update: (state: State, msg: Msg) => State,
     msg?: Msg,
-    middleware: Middleware<Msg>
+    middleware?: Middleware<Msg>
   }
 ): [Signal<State>, (msg: Msg) => void] => {
   const [state, setState] = signal(initial)


### PR DESCRIPTION
This means users don't have to specify one if they don't need it.