### PR TITLE
Update signature of component()

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,34 +410,39 @@ const Modal = (isHidden, children) => div(
 Spellcaster Hyperscript also offers a lightweight way to define Web Components:
 
 ```js
-import {component} from 'spellcaster/hyperscript.js'
+import { component, css } from "spellcaster/hyperscript.js"
 
-// Define component, returning hyperscript tag
+// Define component, returning a hyperscript function
 const Title = component({
-  tag: 'x-title',
-  css: () => css`
+  tag: "x-title"",
+  styles: () => [
+    css`
     :host {
       display: block;
     }
-  `,
-  html: ({title}) => {
+    `
+  ],
+  render: (title) => {
     return h(
-      'h1',
-      {className: 'title'},
+      "h1",
+      { className: "title" },
       text(title)
     )
   }
 })
 
-const [title, setTitle] = signal('Hello Component!')
+const [title, setTitle] = signal("Hello Component!")
 
 // Create instance of component element
 const element = Title({
-  title
+  id: "title",
+  state: title
 })
 ```
 
-If you want more control, you can also extend the underlying `SpellcasterElement` component class.
+All components defined with `component()` have a `state` property which can be used to set the component's state. `render()` is called whenever the `state` property is set, and the element returned by `render()` replaces the current contents of the shadow DOM. As with other elements in Spellcaster, this is typically done just once. You construct the element, passing in one or more signals, and let fine-grained reactivity handle the rest.
+
+If you want more control, you can also extend the underlying `SpellcasterElement` component class directly.
 
 ### Dynamic lists
 

--- a/src/hyperscript.ts
+++ b/src/hyperscript.ts
@@ -1,55 +1,50 @@
-import {
-  effect,
-  takeValues,
-  sample,
-  Signal
-} from './spellcaster.js'
+import { effect, takeValues, sample, Signal } from "./spellcaster.js";
 
-export  {cid, getId, indexById, index, Identifiable} from './util.js'
+export { cid, getId, indexById, index, Identifiable } from "./util.js";
 
 /** A view-constructing function */
-export type View<State> = (state: Signal<State>) => HTMLElement
+export type View<State> = (state: Signal<State>) => HTMLElement;
 
 /** Symbol for list item key */
-const __key__ = Symbol('list item key')
+const __key__ = Symbol("list item key");
 
 /**
  * Create a function to efficiently render a dynamic list of views on a
  * parent element.
  */
-export const repeat = <Key, State>(
-  states: Signal<Map<Key, State>>,
-  view: View<State>
-) => (parent: HTMLElement) => effect(() => {
-  // Build an index of children and a list of children to remove.
-  // Note that we must build a list of children to remove, since
-  // removing in-place would change the live node list and bork iteration.
-  const children = new Map()
-  const removes = []
-  for (const child of parent.children) {
-    children.set(child[__key__], child)
-    if (!states().has(child[__key__])) {
-      removes.push(child)
-    }
-  }
+export const repeat =
+  <Key, State>(states: Signal<Map<Key, State>>, view: View<State>) =>
+  (parent: HTMLElement) =>
+    effect(() => {
+      // Build an index of children and a list of children to remove.
+      // Note that we must build a list of children to remove, since
+      // removing in-place would change the live node list and bork iteration.
+      const children = new Map();
+      const removes = [];
+      for (const child of parent.children) {
+        children.set(child[__key__], child);
+        if (!states().has(child[__key__])) {
+          removes.push(child);
+        }
+      }
 
-  for (const child of removes) {
-    parent.removeChild(child)
-  }
+      for (const child of removes) {
+        parent.removeChild(child);
+      }
 
-  let i = 0
-  for (const key of states().keys()) {
-    const index = i++
-    const child = children.get(key)
-    if (child != null) {
-      insertElementAt(parent, child, index)
-    } else {
-      const child = view(takeValues(() => states().get(key)))
-      child[__key__] = key
-      insertElementAt(parent, child, index)
-    }
-  }
-})
+      let i = 0;
+      for (const key of states().keys()) {
+        const index = i++;
+        const child = children.get(key);
+        if (child != null) {
+          insertElementAt(parent, child, index);
+        } else {
+          const child = view(takeValues(() => states().get(key)));
+          child[__key__] = key;
+          insertElementAt(parent, child, index);
+        }
+      }
+    });
 
 /**
  * Insert element at index.
@@ -61,43 +56,40 @@ export const repeat = <Key, State>(
 export const insertElementAt = (
   parent: HTMLElement,
   element: HTMLElement,
-  index: number
+  index: number,
 ) => {
-  const elementAtIndex = parent.children[index]
+  const elementAtIndex = parent.children[index];
   if (elementAtIndex === element) {
-    return
+    return;
   }
-  parent.insertBefore(element, elementAtIndex)
-}
+  parent.insertBefore(element, elementAtIndex);
+};
 
-export const children = (
-  ...children: Array<HTMLElement | string>
-) => (parent: HTMLElement) => {
-  parent.replaceChildren(...children)
-}
+export const children =
+  (...children: Array<HTMLElement | string>) =>
+  (parent: HTMLElement) => {
+    parent.replaceChildren(...children);
+  };
 
-export const shadow = (
-  ...children: Array<HTMLElement | string>
-) => (parent: HTMLElement) => {
-  parent.attachShadow({mode: 'open'})
-  parent.shadowRoot.replaceChildren(...children)
-}
+export const shadow =
+  (...children: Array<HTMLElement | string>) =>
+  (parent: HTMLElement) => {
+    parent.attachShadow({ mode: "open" });
+    parent.shadowRoot.replaceChildren(...children);
+  };
 
 /**
  * Write a value or signal of values to the text content of a parent element.
  * Value will be coerced to string. If nullish, will be coerced to empty string.
  */
-export const text = (
-  text: Signal<any> | any
-) => parent =>
-  effect(() => setProp(parent, 'textContent', sample(text) ?? ''))
+export const text = (text: Signal<any> | any) => (parent) =>
+  effect(() => setProp(parent, "textContent", sample(text) ?? ""));
 
-const isArray = Array.isArray
+const isArray = Array.isArray;
 
-export type ElementConfigurator = (
-  Array<HTMLElement | string> |
-  ((element: HTMLElement) => void)
-)
+export type ElementConfigurator =
+  | Array<HTMLElement | string>
+  | ((element: HTMLElement) => void);
 
 /**
  * Signals-aware hyperscript.
@@ -107,25 +99,24 @@ export type ElementConfigurator = (
  *   properties to set on the element.
  * @param configure - either a function called with the element to configure it,
  *  or an array of HTMLElements and strings to append. Optional.
- * @returns {HTMLElement}
  */
 export const h = (
   tag: string,
   properties: Record<string, any> | Signal<Record<string, any>>,
-  configure: ElementConfigurator = noConfigure
-) => {
-  const element = document.createElement(tag)
+  configure: ElementConfigurator = noConfigure,
+): HTMLElement => {
+  const element = document.createElement(tag);
 
-  effect(() => setProps(element, sample(properties)))
-  configureElement(element, configure)
+  effect(() => setProps(element, sample(properties)));
+  configureElement(element, configure);
 
-  return element
-}
+  return element;
+};
 
 type TagFactory = (
   properties: Record<string, any> | Signal<Record<string, any>>,
-  configure?: ElementConfigurator
-) => HTMLElement
+  configure?: ElementConfigurator,
+) => HTMLElement;
 
 /**
  * Create a tag factory function - a specialized version of `h()` for a
@@ -134,8 +125,10 @@ type TagFactory = (
  * const div = tag('div')
  * div({className: 'wrapper'})
  */
-export const tag = (tag: string): TagFactory =>
-  (properties, configure=noConfigure) => h(tag, properties, configure)
+export const tag =
+  (tag: string): TagFactory =>
+  (properties, configure = noConfigure) =>
+    h(tag, properties, configure);
 
 /**
  * Create a tag factory function by accessing any property of `tags`.
@@ -146,44 +139,41 @@ export const tag = (tag: string): TagFactory =>
  * const {div} = tags
  * div({className: 'wrapper'})
  */
-export const tags: Record<string, TagFactory> = new Proxy(
-  Object.freeze({}),
-  {
-    get: (_, key): TagFactory => {
-      if (typeof key !== 'string') {
-        throw new TypeError('Tag must be string')
-      }
-      return tag(key)
+export const tags: Record<string, TagFactory> = new Proxy(Object.freeze({}), {
+  get: (_, key): TagFactory => {
+    if (typeof key !== "string") {
+      throw new TypeError("Tag must be string");
     }
-  }
-)
+    return tag(key);
+  },
+});
 
-const noConfigure = (parent: HTMLElement) => {}
+const noConfigure = (parent: HTMLElement) => {};
 
 const configureElement = (
   element: HTMLElement,
-  configure: ElementConfigurator = noConfigure
+  configure: ElementConfigurator = noConfigure,
 ) => {
   if (isArray(configure)) {
-    element.replaceChildren(...configure)
+    element.replaceChildren(...configure);
   } else {
-    configure(element)
+    configure(element);
   }
-}
+};
 
 /**
  * Layout-triggering DOM properties.
  * @see https://gist.github.com/paulirish/5d52fb081b3570c81e3a
  */
-const LAYOUT_TRIGGERING_PROPS = new Set(['innerText'])
+const LAYOUT_TRIGGERING_PROPS = new Set(["innerText"]);
 
 /**
  * Set object key, but only if value has actually changed.
- * This is useful when setting keys on DOM elements, where setting the same 
+ * This is useful when setting keys on DOM elements, where setting the same
  * value twice might trigger an unnecessary reflow or a style recalc.
  * prop caches the written value and only writes the new value if it
  * is different from the last-written value.
- * 
+ *
  * In most cases, we can simply read the value of the DOM property itself.
  * However, there are footgun properties such as `innerText` which
  * will trigger reflow if you read from them. In these cases we warn developers.
@@ -193,44 +183,39 @@ const LAYOUT_TRIGGERING_PROPS = new Set(['innerText'])
  * @param key - the key
  * @param value - the value to set
  */
-export const setProp = (
-  element: Node,
-  key: string,
-  value: any
-) => {
+export const setProp = (element: Node, key: string, value: any) => {
   if (LAYOUT_TRIGGERING_PROPS.has(key)) {
-    console.warn(`Checking property value for ${key} triggers layout. Consider writing to this property without using setProp().`)
+    console.warn(
+      `Checking property value for ${key} triggers layout. Consider writing to this property without using setProp().`,
+    );
   }
 
   if (element[key] !== value) {
-    element[key] = value
+    element[key] = value;
   }
-}
+};
 
 /**
  * Set properties on an element, but only if the value has actually changed.
  */
-const setProps = (
-  element: Node,
-  props: Record<string, any>
-) => {
+const setProps = (element: Node, props: Record<string, any>) => {
   for (const [key, value] of Object.entries(props)) {
-    setProp(element, key, value)
+    setProp(element, key, value);
   }
-}
+};
 
-const stylesheetCache = new Map<string, CSSStyleSheet>()
+const stylesheetCache = new Map<string, CSSStyleSheet>();
 
 /** Get or create a cached stylesheet from a string */
 export const stylesheet = (cssString: string): CSSStyleSheet => {
   if (stylesheetCache.has(cssString)) {
-    return stylesheetCache.get(cssString)
+    return stylesheetCache.get(cssString);
   }
-  const sheet = new CSSStyleSheet()
-  sheet.replaceSync(cssString)
-  stylesheetCache.set(cssString, sheet)
-  return sheet
-}
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync(cssString);
+  stylesheetCache.set(cssString, sheet);
+  return sheet;
+};
 
 /**
  * CSS template literal tag
@@ -238,99 +223,102 @@ export const stylesheet = (cssString: string): CSSStyleSheet => {
  */
 export const css = (parts: TemplateStringsArray) => {
   if (parts.length !== 1) {
-    throw new TypeError(`css string must not contain dynamic replacements`)
+    throw new TypeError(`css string must not contain dynamic replacements`);
   }
-  const [cssString] = parts
-  return stylesheet(cssString)
-}
+  const [cssString] = parts;
+  return stylesheet(cssString);
+};
 
 /**
  * Custom element base for Spellcaster
  */
 export class SpellcasterElement<T> extends HTMLElement {
-  #state: T | undefined = undefined
-  #shadow: ShadowRoot
+  #state: T | undefined = undefined;
+  #shadow: ShadowRoot;
 
   constructor() {
-    super()
-    this.#shadow = this.createShadow()
-    this.#shadow.adoptedStyleSheets = this.css()
+    super();
+    this.#shadow = this.createShadow();
+    this.#shadow.adoptedStyleSheets = this.styles();
   }
 
   createShadow() {
-    return this.attachShadow({mode: 'closed'})
+    return this.attachShadow({ mode: "closed" });
   }
 
-  css(): CSSStyleSheet[] {
-    return []
+  styles(): CSSStyleSheet[] {
+    return [];
   }
 
-  html(state: T): Node {
-    return new DocumentFragment()
+  render(state: T): Node {
+    return new DocumentFragment();
   }
 
   setState(state: T) {
-    this.#state = state
-    this.#shadow.replaceChildren(this.html(state))
+    this.#state = state;
+    this.#shadow.replaceChildren(this.render(state));
   }
 
   get state() {
-    return this.#state
+    return this.#state;
   }
 
   set state(state: T) {
-    this.setState(state)
+    this.setState(state);
   }
 }
 
-const noCSS = () => []
+const noStyles = () => [];
 
 /**
  * Define and register a custom reactive element.
  * Returns a hyperscript function that creates an instance of the element.
- * 
+ *
  * Calling `setState()` or `element.state = value` will rebuild the element's
  * shadow DOM using the `html()` function. This is typically done once at
  * construction, and then signals are allowed to perform fine-grained from
  * there on. However, you can call `setState()` or `element.state = value` at
  * any time to rebuild and re-bind the element's signals.
- * 
+ *
  * @example
  * const Foo = component({
  *   tag: 'x-foo',
- *   css: () => [css(`h1 { color: red; }`)],
- *   html: (state) => {
+ *   styles: () => [css(`h1 { color: red; }`)],
+ *   render: (state) => {
  *     return div({}, text(() => state().title))
  *   }
- * }
- * 
- * const fooEl = Foo(someSignal)
+ * });
+ *
+ * const state = signal({title: 'Hello, world!'});
+ *
+ * const fooEl = Foo({
+ *   className: 'foo',
+ *   state,
+ * });
  */
-export const component = ({
+export const component = <T>({
   tag,
-  css = noCSS,
-  html
+  styles = noStyles,
+  render,
+}: {
+  tag: string;
+  styles?: () => CSSStyleSheet[];
+  render: (state: T) => HTMLElement | DocumentFragment;
 }) => {
-  class CustomSpellcasterElement<T> extends SpellcasterElement<T> {
-    css() {
-      return css()
+  class CustomSpellcasterElement extends SpellcasterElement<T> {
+    styles() {
+      return styles();
     }
 
-    html(state: T) {
-      return html(state)
+    render(state: T) {
+      return render(state);
     }
   }
 
-  customElements.define(tag, CustomSpellcasterElement)
+  customElements.define(tag, CustomSpellcasterElement);
 
-  const create = <T>(
-    state: T,
-    configure: ElementConfigurator = noConfigure
-  ) => {
-    const element = h(tag, {}, configure) as SpellcasterElement<T>
-    element.setState(state)
-    return element
-  }
+  const create = (props = {}, configure: ElementConfigurator = noConfigure) =>
+    h(tag, props, configure) as CustomSpellcasterElement;
 
-  return create
-}
+  return create;
+};

--- a/src/hyperscript.ts
+++ b/src/hyperscript.ts
@@ -254,17 +254,15 @@ export class SpellcasterElement<T> extends HTMLElement {
     return new DocumentFragment();
   }
 
-  setState(state: T) {
-    this.#state = state;
-    this.#shadow.replaceChildren(this.render(state));
-  }
-
   get state() {
     return this.#state;
   }
 
   set state(state: T) {
-    this.setState(state);
+    if (this.#state !== state) {
+      this.#state = state;
+      this.#shadow.replaceChildren(this.render(state));
+    }
   }
 }
 


### PR DESCRIPTION
A fix that introduces a breaking change.

Fixes https://github.com/gordonbrander/spellcaster/issues/55

- Update signature of `component({tag, styles, render})`: these names avoid collision with `css` template tag
- Update signature of `SpellcasterElement` to use `styles()`, `render()` methods
- Remove `setState` method from `SpellcasterElement`. The property accessors are sufficient.
- Check for `state` equality before rebuilding shadow
- Update signature of returned component `create()` method to take props, allowing state to be set as a prop, and allowing classes, etc to be set on components, in addition to state.
- Fix type signature of component: we previously had the generic `T` in the wrong place
- Format with prettier