### PR TITLE
Fix component type inference

### DIFF
--- a/examples/counter-component/main.js
+++ b/examples/counter-component/main.js
@@ -1,27 +1,26 @@
-import {signal, hyperscript} from '../../bundle/spellcaster.js'
-const {text, component} = hyperscript
-const {div, button} = hyperscript.tags
+import { signal, hyperscript } from "../../bundle/spellcaster.js";
+const { text, component } = hyperscript;
+const { div, button } = hyperscript.tags;
 
 const Counter = component({
-  tag: 'x-counter',
-  html: ({count, setCount}) => {
-    return div(
-      {className: 'counter'},
-      [
-        div({className: 'counter-text'}, text(count)),
-        button(
-          {
-            className: 'counter-button',
-            onclick: () => setCount(count() + 1)
-          },
-          text('Increment')
-        )
-      ]
-    )
-  }
-})
+  tag: "x-counter",
+  render: ({ count, setCount }) => {
+    return div({ className: "counter" }, [
+      div({ className: "counter-text" }, text(count)),
+      button(
+        {
+          className: "counter-button",
+          onclick: () => setCount(count() + 1),
+        },
+        text("Increment"),
+      ),
+    ]);
+  },
+});
 
-const [count, setCount] = signal(0)
-const counter = Counter({count, setCount})
+const [count, setCount] = signal(0);
+const counter = Counter({
+  state: { count, setCount },
+});
 
-document.body.replaceChildren(counter)
+document.body.replaceChildren(counter);


### PR DESCRIPTION
...with more specific typing. TypeScript really seemed to be getting tripped up on infering the type of specialized components. This PR attempts to resolve that by pinning down the types.