### PR TITLE
Update middleware signature to ~ match Redux

### DIFF
--- a/src/spellcaster.ts
+++ b/src/spellcaster.ts
@@ -162,10 +162,15 @@ export const takeValues = <T>(maybeSignal: Signal<T | null | undefined>) => {
   });
 };
 
-/** The ID function */
-export const id = (x: any) => x;
+const noware =
+  <State, Msg>(_state: State) =>
+  (send: (msg: Msg) => void) => {
+    return send;
+  };
 
-export type Middleware<Msg> = (send: (msg: Msg) => void) => (msg: Msg) => void;
+export type Middleware<State, Msg> = (
+  state: Signal<State>,
+) => (send: (msg: Msg) => void) => (msg: Msg) => void;
 
 /**
  * Create reducer-style store for state.
@@ -188,25 +193,26 @@ export const store = <State, Msg>({
   state: initial,
   update,
   msg = undefined,
-  middleware = id,
+  middleware = noware,
 }: {
   state: State;
   update: (state: State, msg: Msg) => State;
   msg?: Msg;
-  middleware?: Middleware<Msg>;
+  middleware?: Middleware<State, Msg>;
 }): [Signal<State>, (msg: Msg) => void] => {
   const [state, setState] = signal(initial);
 
   /** Send a message to the store */
   const send = (msg: Msg) => setState(update(state(), msg));
   /** Decorated send function with middleware */
-  const sendWithMiddleware = middleware(send);
+  const decorate = middleware(state);
+  const sendDecorated = decorate(send);
 
   if (msg) {
-    sendWithMiddleware(msg);
+    sendDecorated(msg);
   }
 
-  return [state, sendWithMiddleware];
+  return [state, sendDecorated];
 };
 
 export type Effect<Msg> = (() => Promise<Msg>) | (() => Msg);
@@ -216,10 +222,12 @@ export type Effect<Msg> = (() => Promise<Msg>) | (() => Msg);
  * Effects are modeled as zero-argument functions.
  *
  * @example
- * const fx = (msg: Msg) => {
+ * const fx = (state: State, msg: Msg) => {
  *   switch (msg.type) {
  *   case "fetch":
- *     const req = async () => Msg.fetched(await fetch(msg.url).json())
+ *     const req = async () => Msg.fetched(
+ *       await fetch(state.url, msg.endpoint).json()
+ *     )
  *     return [req]
  *   default:
  *     return []
@@ -233,7 +241,8 @@ export type Effect<Msg> = (() => Promise<Msg>) | (() => Msg);
  * })
  */
 export const fxware =
-  <Msg>(generateFx: (msg: Msg) => Iterable<Effect<Msg>>) =>
+  <State, Msg>(generateFx: (state: State, msg: Msg) => Iterable<Effect<Msg>>) =>
+  (state: Signal<State>) =>
   (send: (msg: Msg) => void) => {
     const forkFx = async (fx: Effect<Msg>) => sendWithFx(await fx());
 
@@ -245,7 +254,7 @@ export const fxware =
 
     const sendWithFx = (msg: Msg) => {
       send(msg);
-      forkAllFx(generateFx(msg));
+      forkAllFx(generateFx(state(), msg));
     };
 
     return sendWithFx;
@@ -271,12 +280,14 @@ export const logware =
     name?: string;
     debug?: boolean | Signal<boolean>;
   }) =>
-  <Msg>(send: (msg: Msg) => void) =>
+  <State, Msg>(state: Signal<State>) =>
+  (send: (msg: Msg) => void) =>
   (msg: Msg) => {
     if (sample(debug)) {
-      console.log(name, msg);
+      console.log(`${name} < msg`, msg);
     }
     send(msg);
+    console.log(`${name} > state`, state());
   };
 
 /**
@@ -284,6 +295,13 @@ export const logware =
  * Order of execution will be from top to bottom.
  */
 export const middleware =
-  <Msg>(...middlewares: Array<Middleware<Msg>>): Middleware<Msg> =>
-  (send: (msg: Msg) => void) =>
-    middlewares.reduce((send, middleware) => middleware(send), send);
+  <State, Msg>(
+    ...middlewares: Array<Middleware<State, Msg>>
+  ): Middleware<State, Msg> =>
+  (state: Signal<State>) =>
+  (send: (msg: Msg) => void) => {
+    return middlewares.reduce((send, middleware) => {
+      const decorate = middleware(state);
+      return decorate(send);
+    }, send);
+  };

--- a/src/spellcaster.ts
+++ b/src/spellcaster.ts
@@ -253,8 +253,8 @@ export const fxware =
     };
 
     const sendWithFx = (msg: Msg) => {
-      send(msg);
       forkAllFx(generateFx(state(), msg));
+      send(msg);
     };
 
     return sendWithFx;

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
-import { describe, it } from "mocha"
-import { strict as assert, strictEqual as assertEqual, fail } from "assert"
+import { describe, it } from "mocha";
+import { strict as assert, strictEqual as assertEqual, fail } from "assert";
 
 import {
   throttled,
@@ -11,388 +11,384 @@ import {
   middleware,
   isSignal,
   sample,
-  takeValues
-} from "../dist/spellcaster.js"
+  takeValues,
+} from "../dist/spellcaster.js";
 
-const delay = (value, ms) => new Promise(resolve => {
-  setTimeout(
-    () => resolve(value),
-    ms
-  )
-})
+const delay = (value, ms) =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve(value), ms);
+  });
 
-describe('throttled', () => {
-  it('batches calls, only executing once per microtask', async () => {
-    let count = 0
+describe("throttled", () => {
+  it("batches calls, only executing once per microtask", async () => {
+    let count = 0;
 
     const inc = throttled(() => {
-      count++
-    })
+      count++;
+    });
 
-    inc()
-    inc()
-    inc()
+    inc();
+    inc();
+    inc();
 
-    await Promise.resolve()
+    await Promise.resolve();
 
-    assert(count === 1)
-  })
-})
+    assert(count === 1);
+  });
+});
 
-describe('signal getter', () => {
-  it('returns value', () => {
-    const [state, _] = signal(0)
-    assert(state() === 0)
-  })
+describe("signal getter", () => {
+  it("returns value", () => {
+    const [state, _] = signal(0);
+    assert(state() === 0);
+  });
 
-  it('triggers reaction when read within reactive scope', done => {
-    const [state, setState] = signal(false)
+  it("triggers reaction when read within reactive scope", (done) => {
+    const [state, setState] = signal(false);
 
     effect(() => {
       if (state()) {
-        done()
+        done();
       }
-    })
+    });
 
-    setState(true)
-  })
-})
+    setState(true);
+  });
+});
 
-describe('signal setter', () => {
-  it('sets value immediately', () => {
-    const [state, setState] = signal(0)
-    setState(10)
-    assert(state() === 10)
-  })
+describe("signal setter", () => {
+  it("sets value immediately", () => {
+    const [state, setState] = signal(0);
+    setState(10);
+    assert(state() === 10);
+  });
 
-  it('does not trigger reactions for values that are equal to the currently set value', async() => {
-    const [state, setState] = signal(0)
-    setState(10)
-    setState(10)
-    setState(10)
+  it("does not trigger reactions for values that are equal to the currently set value", async () => {
+    const [state, setState] = signal(0);
+    setState(10);
+    setState(10);
+    setState(10);
 
-    let hitCount = 0
+    let hitCount = 0;
     effect(() => {
       // Access value so that effect triggers
-      state()
+      state();
 
-      hitCount++
-    })
+      hitCount++;
+    });
 
-    await Promise.resolve()
+    await Promise.resolve();
 
-    assertEqual(hitCount, 1)
-  })
-})
+    assertEqual(hitCount, 1);
+  });
+});
 
-describe('isSignal', () => {
-  it('returns true for signal', () => {
-    const [value, setValue] = signal(0)
-    assert(isSignal(value))
-  })
+describe("isSignal", () => {
+  it("returns true for signal", () => {
+    const [value, setValue] = signal(0);
+    assert(isSignal(value));
+  });
 
-  it('returns true for computed', () => {
-    const [a, setA] = signal(0)
-    const [b, setB] = signal(0)
-    const sum = computed(() => a() + b())
-    assert(isSignal(sum))
-  })
+  it("returns true for computed", () => {
+    const [a, setA] = signal(0);
+    const [b, setB] = signal(0);
+    const sum = computed(() => a() + b());
+    assert(isSignal(sum));
+  });
 
-  it('returns true for any zero-argument function', () => {
-    const constantZero = () => 0
-    assert(isSignal(constantZero))
-  })
+  it("returns true for any zero-argument function", () => {
+    const constantZero = () => 0;
+    assert(isSignal(constantZero));
+  });
 
-  it('returns false for functions with arguments ', () => {
-    const id = value => value
-    assert(isSignal(id) === false)
-  })
-})
+  it("returns false for functions with arguments ", () => {
+    const id = (value) => value;
+    assert(isSignal(id) === false);
+  });
+});
 
-describe('sample', () => {
-  it('samples a value', () => {
-    assert(sample(0) === 0)
-  })
+describe("sample", () => {
+  it("samples a value", () => {
+    assert(sample(0) === 0);
+  });
 
-  it('samples a signal', () => {
-    const constantZero = () => 0
-    assert(sample(constantZero) === 0)
-  })
+  it("samples a signal", () => {
+    const constantZero = () => 0;
+    assert(sample(constantZero) === 0);
+  });
 
-  it('treats functions with arguments as values, not signals', () => {
-    const id = value => value
-    assert(sample(id) === id)
-  })
-})
+  it("treats functions with arguments as values, not signals", () => {
+    const id = (value) => value;
+    assert(sample(id) === id);
+  });
+});
 
-describe('effect', () => {
-  it('executes once on initialization', done => {
-    effect(done)
-  })
+describe("effect", () => {
+  it("executes once on initialization", (done) => {
+    effect(done);
+  });
 
-  it('reacts to signals once per microtask, batching multiple updates', done => {
-    const [a, setA] = signal(1)
-    const [b, setB] = signal(1)
+  it("reacts to signals once per microtask, batching multiple updates", (done) => {
+    const [a, setA] = signal(1);
+    const [b, setB] = signal(1);
 
-
-    let count = 0
+    let count = 0;
     effect(() => {
-      count++
+      count++;
       if (count > 1) {
-        fail('Effect fired too many times')
+        fail("Effect fired too many times");
       } else if (count === 1) {
-        done()
+        done();
       }
-    })
+    });
 
-    setA(10)
-    setB(10)
-  })
+    setA(10);
+    setB(10);
+  });
 
-  it('runs the cleanup function before next execution', async () => {
-    const [counter, setCounter] = signal(0)
+  it("runs the cleanup function before next execution", async () => {
+    const [counter, setCounter] = signal(0);
 
-    let callCount = 0
-    let cleanupCount = 0
+    let callCount = 0;
+    let cleanupCount = 0;
     effect(() => {
-      counter()
-      callCount++
-      cleanupCount++
-      return () => cleanupCount--
-    })
-    await delay(null, 1)
-    setCounter(1)
-    await delay(null, 1)
-    setCounter(2)
-    await delay(null, 1)
-    setCounter(3)
-    await delay(null, 1)
+      counter();
+      callCount++;
+      cleanupCount++;
+      return () => cleanupCount--;
+    });
+    await delay(null, 1);
+    setCounter(1);
+    await delay(null, 1);
+    setCounter(2);
+    await delay(null, 1);
+    setCounter(3);
+    await delay(null, 1);
 
-    assertEqual(callCount, 4)
-    assertEqual(cleanupCount, 1)
-  })
+    assertEqual(callCount, 4);
+    assertEqual(cleanupCount, 1);
+  });
 
-  it('runs the cleanup when running the dispose function', async () => {
-    let cleanupCount = 0
+  it("runs the cleanup when running the dispose function", async () => {
+    let cleanupCount = 0;
     const dispose = effect(() => {
-      return () => cleanupCount++
-    })
-    dispose()
-    assertEqual(cleanupCount, 1)
-  })
-})
+      return () => cleanupCount++;
+    });
+    dispose();
+    assertEqual(cleanupCount, 1);
+  });
+});
 
-describe('computed', () => {
-  it('computes immediately and returns value', () => {
-    const [a, setA] = signal(1)
-    const [b, setB] = signal(1)
-    const sum = computed(() => a() + b())
+describe("computed", () => {
+  it("computes immediately and returns value", () => {
+    const [a, setA] = signal(1);
+    const [b, setB] = signal(1);
+    const sum = computed(() => a() + b());
 
-    assert(sum() === 2)
-  })
+    assert(sum() === 2);
+  });
 
-  it('recomputes when signal dependencies change, once per microtask, batching multiple updates', async () => {
-    const [a, setA] = signal(1)
-    const [b, setB] = signal(1)
-    const sum = computed(() => a() + b())
+  it("recomputes when signal dependencies change, once per microtask, batching multiple updates", async () => {
+    const [a, setA] = signal(1);
+    const [b, setB] = signal(1);
+    const sum = computed(() => a() + b());
 
-    assert(sum() === 2)
+    assert(sum() === 2);
 
-    setA(10)
-    setB(10)
+    setA(10);
+    setB(10);
 
     // Recomputes are batched on next microtask, so await next microtask
-    await Promise.resolve()
+    await Promise.resolve();
 
-    assert(sum() === 20)
-  })
-})
+    assert(sum() === 20);
+  });
+});
 
-describe('store', () => {
-  it('returns a signal as the first item of the array pair', () => {
-    const initial = {}
-    const update = (state, msg) => ({})
-
-    const [state, send] = store({
-      state: initial,
-      update
-    })
-
-    assert(isSignal(state))
-  })
-
-  it('returns a send function as the second item of the array pair', () => {
-    const initial = {}
-    const update = (state, msg) => ({})
+describe("store", () => {
+  it("returns a signal as the first item of the array pair", () => {
+    const initial = {};
+    const update = (state, msg) => ({});
 
     const [state, send] = store({
       state: initial,
-      update
-    })
+      update,
+    });
 
-    assertEqual(typeof send, 'function')
-    assertEqual(send.length, 1)
-  })
+    assert(isSignal(state));
+  });
 
-  it('updates the state immediately', () => {
-    const Msg = {}
-    Msg.inc = {type: 'inc'}
-
-    const init = () => ({count: 0})
-
-    const update = (state, msg) => {
-      switch (msg.type) {
-      case 'inc':
-        return {...state, count: state.count + 1}
-      default:
-        return state
-      }
-    }
+  it("returns a send function as the second item of the array pair", () => {
+    const initial = {};
+    const update = (state, msg) => ({});
 
     const [state, send] = store({
-      state: init(),
-      update
-    })
+      state: initial,
+      update,
+    });
 
-    assert(state().count === 0)
+    assertEqual(typeof send, "function");
+    assertEqual(send.length, 1);
+  });
 
-    send(Msg.inc)
+  it("updates the state immediately", () => {
+    const Msg = {};
+    Msg.inc = { type: "inc" };
 
-    assert(state().count === 1)
-  })
-})
-
-describe('fxware', () => {
-  it('runs effects when plugged in as store fx driver', async () => {
-    const TIMEOUT = 1
-
-    const Msg = {}
-    Msg.incLater = {type: 'incLater'}
-    Msg.inc = {type: 'inc'}
-
-    const init = () => ({count: 0})
+    const init = () => ({ count: 0 });
 
     const update = (state, msg) => {
       switch (msg.type) {
-      case 'inc':
-        return {...state, count: state.count + 1}
-      default:
-        return state
+        case "inc":
+          return { ...state, count: state.count + 1 };
+        default:
+          return state;
       }
-    }
-
-    const fx = msg => {
-      switch (msg.type) {
-      case 'incLater':
-        const incFx = () => delay(Msg.inc, TIMEOUT)
-        return [incFx]
-      default:
-        return []
-      }
-    }
+    };
 
     const [state, send] = store({
       state: init(),
       update,
-      middleware: fxware(fx)
-    })
+    });
 
-    send(Msg.incLater)
+    assert(state().count === 0);
 
-    await delay(null, TIMEOUT + 1)
+    send(Msg.inc);
 
-    assertEqual(state().count, 1)
-  })
+    assert(state().count === 1);
+  });
+});
 
-  it('runs effects that immediately return a value', async () => {
-    const TIMEOUT = 1
+describe("fxware", () => {
+  it("runs effects when plugged in as store fx driver", async () => {
+    const TIMEOUT = 1;
 
-    const Msg = {}
-    Msg.incLater = {type: 'incLater'}
-    Msg.inc = {type: 'inc'}
+    const Msg = {};
+    Msg.incLater = { type: "incLater" };
+    Msg.inc = { type: "inc" };
 
-    const init = () => ({count: 0})
+    const init = () => ({ count: 0 });
 
     const update = (state, msg) => {
       switch (msg.type) {
-      case 'inc':
-        return {...state, count: state.count + 1}
-      default:
-        return state
+        case "inc":
+          return { ...state, count: state.count + 1 };
+        default:
+          return state;
       }
-    }
+    };
 
-    const fx = msg => {
+    const fx = (_state, msg) => {
       switch (msg.type) {
-      case 'incLater':
-        const incFx = () => Msg.inc
-        return [incFx]
-      default:
-        return []
+        case "incLater":
+          const incFx = () => delay(Msg.inc, TIMEOUT);
+          return [incFx];
+        default:
+          return [];
       }
-    }
+    };
 
     const [state, send] = store({
       state: init(),
       update,
-      middleware: fxware(fx)
-    })
+      middleware: fxware(fx),
+    });
 
-    send(Msg.incLater)
+    send(Msg.incLater);
 
-    await delay(null, TIMEOUT + 1)
+    await delay(null, TIMEOUT + 1);
 
-    assertEqual(state().count, 1)
-  })
-})
+    assertEqual(state().count, 1);
+  });
 
-describe('middleware', () => {
-  it('it composes the fx drivers', done => {
-    const driverA = send => msg => send(`a${msg}`)
-    const driverB = send => msg => send(`b${msg}`)
-    const driverC = send => msg => send(`c${msg}`)
+  it("runs effects that immediately return a value", async () => {
+    const TIMEOUT = 1;
 
-    const driver = middleware(
-      driverA,
-      driverB,
-      driverC
-    )
+    const Msg = {};
+    Msg.incLater = { type: "incLater" };
+    Msg.inc = { type: "inc" };
 
-    const send = msg => {
-      assertEqual(msg, 'abc123')
-      done()
-    }
+    const init = () => ({ count: 0 });
 
-    const sendWithDrivers = driver(send)
+    const update = (state, msg) => {
+      switch (msg.type) {
+        case "inc":
+          return { ...state, count: state.count + 1 };
+        default:
+          return state;
+      }
+    };
 
-    sendWithDrivers('123')
-  })
-})
+    const fx = (_state, msg) => {
+      switch (msg.type) {
+        case "incLater":
+          const incFx = () => Msg.inc;
+          return [incFx];
+        default:
+          return [];
+      }
+    };
 
-describe('takeValues', () => {
-  it('ends the signal on the first null or undefined value', async () => {
-    const [maybeValue, setMaybeValue] = signal('a')
+    const [state, send] = store({
+      state: init(),
+      update,
+      middleware: fxware(fx),
+    });
 
-    const value = takeValues(maybeValue)
-    setMaybeValue('b')
+    send(Msg.incLater);
 
-    await Promise.resolve()
+    await delay(null, TIMEOUT + 1);
 
-    assert(value() === 'b')
+    assertEqual(state().count, 1);
+  });
+});
+
+describe("middleware", () => {
+  it("it composes the fx drivers", (done) => {
+    const driverA = (state) => (send) => (msg) => send(`a${state()}${msg}`);
+    const driverB = (state) => (send) => (msg) => send(`b${state()}${msg}`);
+    const driverC = (state) => (send) => (msg) => send(`c${state()}${msg}`);
+
+    const driver = middleware(driverA, driverB, driverC);
+
+    const state = () => "-";
+
+    const send = (msg) => {
+      assertEqual(msg, "a-b-c-123");
+      done();
+    };
+
+    const decorate = driver(state);
+    const sendDecorated = decorate(send);
+
+    sendDecorated("123");
+  });
+});
+
+describe("takeValues", () => {
+  it("ends the signal on the first null or undefined value", async () => {
+    const [maybeValue, setMaybeValue] = signal("a");
+
+    const value = takeValues(maybeValue);
+    setMaybeValue("b");
+
+    await Promise.resolve();
+
+    assert(value() === "b");
 
     // Should end `value` signal
-    setMaybeValue(null)
+    setMaybeValue(null);
 
-    await Promise.resolve()
+    await Promise.resolve();
 
-    assert(value() === 'b')
+    assert(value() === "b");
 
     // `value` signal should be ended at this point, and should never see these.
-    setMaybeValue('c')
-    setMaybeValue('d')
+    setMaybeValue("c");
+    setMaybeValue("d");
 
-    await Promise.resolve()
+    await Promise.resolve();
 
-    assert(value() === 'b')
-  })
-})
+    assert(value() === "b");
+  });
+});


### PR DESCRIPTION
Middleware is now a function of:
(state: State) => (send: (msg: Msg) => void) => (msg: Msg) => void;

This gives middleware the ability to sample state.

Fxware now samples state, and the fx generating function signature
receives the state as the first argument.

Practically speaking, when I've used an fx manager in applications, I have occasionally wanted access to the program state when generating the effect. This gives middleware that opportunity.