### PR TITLE
Simplify web component helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ With hyperscript, most of the DOM tree is static. Only dynamic properties, text,
 Spellcaster Hyperscript also offers a lightweight helper that transforms any view function into a custom element:
 
 ```js
-import { Signal, always } from "spellcaster/spellcaster.js";
+import { always } from "spellcaster/spellcaster.js";
 import { component, css } from "spellcaster/hyperscript.js";
 
 const styles = css`
@@ -432,11 +432,7 @@ const styles = css`
 }
 `;
 
-const Hello = ({
-  hello
-}: {
-  hello: Signal<string>
-}) => {
+const Hello = ({ hello }) => {
   return h('div', {className: 'title'}, text(hello()));
 };
 

--- a/README.md
+++ b/README.md
@@ -423,8 +423,8 @@ With hyperscript, most of the DOM tree is static. Only dynamic properties, text,
 Spellcaster Hyperscript also offers a lightweight helper that transforms any view function into a custom element:
 
 ```js
-import { always } from "spellcaster/spellcaster.js";
-import { component, css } from "spellcaster/hyperscript.js"
+import { Signal, always } from "spellcaster/spellcaster.js";
+import { component, css } from "spellcaster/hyperscript.js";
 
 const styles = css`
 :host {
@@ -433,17 +433,22 @@ const styles = css`
 `;
 
 const Hello = ({
-  hello = always("Hello world")
+  hello
+}: {
+  hello: Signal<string>
 }) => {
-  return h('div', {className: 'title'}, text(hello()))
-}
+  return h('div', {className: 'title'}, text(hello()));
+};
 
-customElements.define("x-hello", component(Hello, { styles }));
+component({
+  tag: 'x-hello',
+  styles,
+  props: { hello: always("Hello") },
+  render: Hello
+});
 ```
 
-View functions that are registered as components receive the element instance as their props argument. Because the view props are an element instance, you must provide default values for all of their custom props. This is because the element instance may not have that property set. `always()` is a useful helper for default values. It creates a signal that never changes.
-
-To access the element instance, you can pass it in as a variable instead of destructuring:
+View functions that are registered as components receive the element instance as their props argument. This allows you to modify the element and use the element's properties as the function's props. To access the element instance, you can pass it in as a variable instead of destructuring:
 
 ```js
 const Hello = (element) => {
@@ -452,10 +457,10 @@ const Hello = (element) => {
 }
 ```
 
-Like the rest of Spellcaster, the component's is called just once, to build the shadow DOM of the element and bind signals to specific places in the DOM. Components wait until you append the element to the DOM to call the view function, giving you an opportunity to set element properties before the view function is run.
+Like the rest of Spellcaster, the component's render function is called just once, to build the shadow DOM of the element and bind signals to specific places in the DOM. The component will wait until you append the element to the DOM to call the render function, giving you an opportunity to set element properties before the element shadow DOM is built.
 
 ```js
-const [hello, setHello] = signal("Hello signals");
+const [hello, setHello] = signal("Bonjour");
 
 // Set a signal to drive the element
 const helloElement = h('x-hello', { hello });

--- a/src/hyperscript.ts
+++ b/src/hyperscript.ts
@@ -261,8 +261,8 @@ export class SpellcasterElement extends HTMLElement {
   /**
    * Build element Shadow DOM.
    * Automatically invoked once, when element is first connected to the DOM.
-   * You may also invoke it yourself manually at any time to build or rebuild
-   * the Shadow DOM.
+   * You may also invoke it yourself manually to build the Shadow DOM before
+   * appending.
    */
   build() {
     if (this.#didBuild) return;

--- a/src/hyperscript.ts
+++ b/src/hyperscript.ts
@@ -285,10 +285,19 @@ export class SpellcasterElement extends HTMLElement {
 }
 
 /**
- * Create a custom element from a view function.
+ * Create a custom element from a view rendering function.
+ * @example
+ * const Foo = component({
+ *   tag: 'x-foo',
+ *   styles: [css(`h1 { color: red; }`)],
+ *   props: { foo: always("") },
+ *   render: ({ foo }) => {
+ *     return div({}, text(foo))
+ *   }
+ * });
  *
- * Function must provide defaults for all props, since the element may not have
- * values for those props defined.
+ * const [foo, setFoo] = signal("Hello world!");
+ * const fooEl = h('x-foo', { foo });
  */
 export const component = <P extends object>({
   tag = undefined,

--- a/src/spellcaster.ts
+++ b/src/spellcaster.ts
@@ -35,6 +35,16 @@ export const signal = <T>(initial: T): [Signal<T>, (value: T) => void] => {
 };
 
 /**
+ * Create a signal that holds a reference to its own setter.
+ */
+export const state = <T>(initial: T) => {
+  const state = new Signal.State(initial);
+  const get = () => state.get();
+  get.set = (value: T) => state.set(value);
+  return get;
+};
+
+/**
  * Create a computed signal
  * Computed sigal takes a zero-argument function, `compute` which may read
  * from any other signal to produce a value.

--- a/src/spellcaster.ts
+++ b/src/spellcaster.ts
@@ -35,16 +35,6 @@ export const signal = <T>(initial: T): [Signal<T>, (value: T) => void] => {
 };
 
 /**
- * Create a signal that holds a reference to its own setter.
- */
-export const state = <T>(initial: T) => {
-  const state = new Signal.State(initial);
-  const get = () => state.get();
-  get.set = (value: T) => state.set(value);
-  return get;
-};
-
-/**
  * Create a computed signal
  * Computed sigal takes a zero-argument function, `compute` which may read
  * from any other signal to produce a value.
@@ -57,6 +47,12 @@ export const computed = <T>(compute: Signal<T>) => {
   const get = () => computed.get();
   return get;
 };
+
+/** A signal that always returns the same value and never changes */
+export const always =
+  <T>(initial: T) =>
+  () =>
+    initial;
 
 /**
  * Given a zero-argument function, create a throttled version of that function


### PR DESCRIPTION
This PR refactors web component helpers to make them simpler and provide better TypeScript types.

```ts
const styles = css`
:host {
  display: block;
}

.hello {
  font-weight: bold;
}
`;

const Hello = ({ greeting }: { greeting: string }) => {
  return h('div', { className: "hello" }, text(greeting))
};

component({
  tag: "x-hello",
  styles,
  props: { greeting: "Hello" },
  render: Hello
});
```