### PR TITLE
fix: Support data properties

### DIFF
--- a/examples/counter/main.js
+++ b/examples/counter/main.js
@@ -13,7 +13,9 @@ const Counter = () => {
         {
           className: 'counter-button',
           onclick: () => setCount(count() + 1),
-          "data-short-desc": "Increases the count by one each time you click this button."
+          attrs: {
+            "data-short-desc": "Increases the count by one each time you click this button."
+          }
         },
         text('Increment')
       )

--- a/examples/counter/main.js
+++ b/examples/counter/main.js
@@ -12,7 +12,8 @@ const Counter = () => {
       button(
         {
           className: 'counter-button',
-          onclick: () => setCount(count() + 1)
+          onclick: () => setCount(count() + 1),
+          "data-short-desc": "Increases the count by one each time you click this button."
         },
         text('Increment')
       )

--- a/src/hyperscript.ts
+++ b/src/hyperscript.ts
@@ -192,9 +192,10 @@ export const setProp = (element: Node, key: string, value: any) => {
     );
   }
 
-  if (key.includes("-") || key === "rel") {
-    if (element instanceof HTMLElement && element.getAttribute(key) !== value) {
-      element.setAttribute(key, value)
+  if (key === "attrs" && typeof value === "object" && element instanceof HTMLElement) {
+    for (const [k, v] of Object.entries(value)) {
+      const value = typeof v === "string" ? v : (v as any).toString()
+      if (element.getAttribute(k) !== value) element.setAttribute(k, value);
     }
   } else if (element[key] !== value) {
     element[key] = value;

--- a/src/hyperscript.ts
+++ b/src/hyperscript.ts
@@ -192,7 +192,11 @@ export const setProp = (element: Node, key: string, value: any) => {
     );
   }
 
-  if (element[key] !== value) {
+  if (key.includes("-") || key === "rel") {
+    if (element instanceof HTMLElement && element.getAttribute(key) !== value) {
+      element.setAttribute(key, value)
+    }
+  } else if (element[key] !== value) {
     element[key] = value;
   }
 };

--- a/src/spellcaster.ts
+++ b/src/spellcaster.ts
@@ -86,6 +86,7 @@ const watcher = new Signal.subtle.Watcher(
     for (const signal of watcher.getPending()) {
       signal.get();
     }
+    watcher.watch();
   }),
 );
 


### PR DESCRIPTION
Fixes #71 and #73

I wasn't sure if I needed to use the [`dataset`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset) property or `getAttribute` + `setAttribute`. I went with the latter, because the former requires you to convert all keys to camel case and I didn't want to introduce a dependency just for that.

This also allows you to use other attributes with a dash in the name such as `aria-label` (instead of using `ariaLabel`).

I also had trouble setting the `rel` attribute so included that in the `if` condition as well. Let me know if you can think of a better way of approaching this.

Tested this with computed properties as well, like so:
```ts
button(
  computed(() => ({
    className: "counter-button",
    onclick: () => setCount(count() + 1),
    "data-count": count(),
  })),
  text("Increment"),
),
```
_(let me know if I need to remove the fix for #71)_